### PR TITLE
sed fix for OS X

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -3,4 +3,10 @@ node r.js -o build.js
 node r.js -o cssIn=../css/styles.css out=output/css/styles.css
 
 cp ../index.html output/index.html
-sed -i 's/js\/libs\/require\/require.js/http:\/\/requirejs.org\/docs\/release\/1.0.5\/minified\/require.js/g' output/index.html
+SEDCMD='sed -i'
+if [[ $OSTYPE == *"darwin"* ]]; then
+  SEDCMD=$SEDCMD' .tmp' 
+fi
+SEDCMD=$SEDCMD' s/js\/libs\/require\/require.js/http:\/\/requirejs.org\/docs\/release\/1.0.5\/minified\/require.js/g output/index.html'
+$SEDCMD
+rm -f output/*.tmp


### PR DESCRIPTION
This is a fix for sed failing on OS X, which was originally brought up in [this issue](https://github.com/thomasdavis/backboneboilerplate/issues/6). Although it was said to be resolved and marked closed, I didn't see a fix in the repo so here is my proposed solution. It's different from what's proposed in the issue comments, because if the stream does get corrupted or the command fails for any reason you'll have a back-up of the original output file. It shouldn't affect any platform other than OS X. 
