### PR TITLE
Whitespace/Semicolons

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
- 
-# Backbone boilerplate 
+
+# Backbone boilerplate
 [http://backboneboilerplate.com](http://backboneboilerplate.com) is a community driven effort to help developers learn and rapidly deploy single page web applications.
 
 ## Philosophy

--- a/build/build.sh
+++ b/build/build.sh
@@ -6,7 +6,7 @@ cp ../index.html output/index.html
 REQUIRE_VERSION='1.0.5'
 SEDCMD='sed -i'
 if [[ $OSTYPE == *"darwin"* ]]; then
-  SEDCMD=$SEDCMD' .tmp' 
+  SEDCMD=$SEDCMD' .tmp'
 fi
 SEDCMD=$SEDCMD' s/js\/libs\/require\/require.js/http:\/\/requirejs.org\/docs\/release\/'$REQUIRE_VERSION'\/minified\/require.js/g output/index.html'
 $SEDCMD

--- a/css/normalize.css
+++ b/css/normalize.css
@@ -35,7 +35,7 @@ body { margin: 0; font-size: 13px; line-height: 1.231; }
 
 body, button, input, select, textarea { font-family: sans-serif; color: #222; }
 
-/* 
+/*
  * These selection declarations have to be separate
  * No text-shadow: twitter.com/miketaylr/status/12228805301
  * Also: hot pink!
@@ -113,7 +113,7 @@ nav ul, nav ol { list-style: none; margin: 0; padding: 0; }
 img { border: 0; -ms-interpolation-mode: bicubic; }
 
 /*
- * Correct overflow displayed oddly in IE9 
+ * Correct overflow displayed oddly in IE9
  */
 
 svg:not(:root) {
@@ -135,9 +135,9 @@ figure { margin: 0; }
 form { margin: 0; }
 fieldset { border: 0; margin: 0; padding: 0; }
 
-/* 
- * 1. Correct color not inheriting in IE6/7/8/9 
- * 2. Correct alignment displayed oddly in IE6/7 
+/*
+ * 1. Correct color not inheriting in IE6/7/8/9
+ * 2. Correct alignment displayed oddly in IE6/7
  */
 
 legend { border: 0; *margin-left: -7px; padding: 0; }
@@ -174,9 +174,9 @@ button, input[type="button"], input[type="reset"], input[type="submit"] { cursor
 input[type="checkbox"], input[type="radio"] { box-sizing: border-box; }
 input[type="search"] { -moz-box-sizing: content-box; -webkit-box-sizing: content-box; box-sizing: content-box; }
 
-/* 
+/*
  * Remove inner padding and border in FF3/4
- * www.sitepen.com/blog/2008/05/14/the-devils-in-the-details-fixing-dojos-toolbar-buttons/ 
+ * www.sitepen.com/blog/2008/05/14/the-devils-in-the-details-fixing-dojos-toolbar-buttons/
  */
 
 button::-moz-focus-inner, input::-moz-focus-inner { border: 0; padding: 0; }
@@ -219,7 +219,7 @@ table { border-collapse: collapse; border-spacing: 0; }
 /* Hide visually and from screenreaders, but maintain layout */
 .invisible { visibility: hidden; }
 
-/* Contain floats: nicolasgallagher.com/micro-clearfix-hack/ */ 
+/* Contain floats: nicolasgallagher.com/micro-clearfix-hack/ */
 .clearfix:before, .clearfix:after { content: ""; display: table; }
 .clearfix:after { clear: both; }
 .clearfix { zoom: 1; }
@@ -247,7 +247,7 @@ table { border-collapse: collapse; border-spacing: 0; }
    Print styles.
    Inlined to avoid required HTTP connection: www.phpied.com/delay-loading-your-print-css/
    ========================================================================== */
- 
+
 @media print {
   * { background: transparent !important; color: black !important; text-shadow: none !important; filter:none !important; -ms-filter: none !important; } /* Black prints faster: sanbeiji.com/archives/953 */
   a, a:visited { color: #444 !important; text-decoration: underline; }

--- a/css/styles.css
+++ b/css/styles.css
@@ -4,13 +4,13 @@
 
 */
 
-/* 
+/*
 ### Third Party
 */
 @import url("normalize.css");
 @import url("960.css");
 
-/* 
+/*
 ### Custom themes
 */
 @import url("theme.css");

--- a/css/theme.css
+++ b/css/theme.css
@@ -6,15 +6,15 @@
 ```
 <div class="divider"></div>
 <div class="main-menu">
-	<ul>
-		<li><a href="">Home</a></li>
-		<li><a href="">Modules</a></li>
-		<li><a href="">Optimize</a></li>
-		<li><a href="">Backbone</a></li>
-		<li><a href="">Views</a></li>
-		<li><a href="">Feedback</a></li>
-	</ul>
-	<div style="clear: both;"></div>
+  <ul>
+    <li><a href="">Home</a></li>
+    <li><a href="">Modules</a></li>
+    <li><a href="">Optimize</a></li>
+    <li><a href="">Backbone</a></li>
+    <li><a href="">Views</a></li>
+    <li><a href="">Feedback</a></li>
+  </ul>
+  <div style="clear: both;"></div>
 </div>
 <div class="divider"></div>
 
@@ -28,35 +28,35 @@
 }
 
 .main-menu {
-	margin: 10px 0 10px 0;
+  margin: 10px 0 10px 0;
 }
 .main-menu ul {
-	margin: 0;
-	padding: 0;
-	list-style: none;
+  margin: 0;
+  padding: 0;
+  list-style: none;
 }
 
 .main-menu li {
-	margin-right: 10px;
-	float: left;
+  margin-right: 10px;
+  float: left;
 }
 .main-menu li a,
 .main-menu li a:visited {
-	padding: 5px;
-	color: #515151;
-	font-size: 18px;
-	text-decoration: none;
-	display: inline-block;
+  padding: 5px;
+  color: #515151;
+  font-size: 18px;
+  text-decoration: none;
+  display: inline-block;
 }
 .main-menu li a.active,
 .main-menu li a:hover {
-	background: #c0c0c0;
-	border-radius: 6px;
+  background: #c0c0c0;
+  border-radius: 6px;
 }
 .divider {  
-	clear: both;
+  clear: both;
   border-top: 1px solid #919191;
-	border-bottom: 1px solid #ececec;
+  border-bottom: 1px solid #ececec;
 }
 /*
 
@@ -69,9 +69,9 @@
 */
 
 .h3 {
-	list-style: none;
-	margin: 0;
-	padding: 0;
+  list-style: none;
+  margin: 0;
+  padding: 0;
 }
 
 h1, h2, h3, h4, h5, h6 {
@@ -99,45 +99,45 @@ adadasd
 <span class="fixie"></span>
 ```
 <ul class="action-list">
-	<li><a href="">download zip</a></li>
-	<li><a href="">view the source</a></li>
-	<li><a href="">watch</a></li>
-	<li><a href="">fork</a></li>
+  <li><a href="">download zip</a></li>
+  <li><a href="">view the source</a></li>
+  <li><a href="">watch</a></li>
+  <li><a href="">fork</a></li>
 </ul>
 ```
 */
 
 .action-list {
-	list-style: none;
-	margin: 0;
-	padding: 0;
+  list-style: none;
+  margin: 0;
+  padding: 0;
 }
 .action-list li {
 
-	text-align: center;
+  text-align: center;
 }
 .action-list li a {
-	font-size: 34px;
-	color: #594936;
-	font-weight: bold;
+  font-size: 34px;
+  color: #594936;
+  font-weight: bold;
 }
 .action-list li a:visited {
-	color: #594936;
-}	
+  color: #594936;
+}  
 
 
 
 body {
-	background: #dddddd url('../images/page_bg.png');
-	color: #11141b;
-	font-family: 'PT Sans', sans-serif;
+  background: #dddddd url('../images/page_bg.png');
+  color: #11141b;
+  font-family: 'PT Sans', sans-serif;
   font-size: 14px;
 }
 
 .logo {
-	color: #5a4935;
-	padding: 0;
-	margin: 0;
+  color: #5a4935;
+  padding: 0;
+  margin: 0;
   text-shadow: 0 1px 1px #fff;
   text-align: center;
   font-family: 'Squada One';
@@ -154,9 +154,9 @@ Boilerplate Stamp!
 ```
 */
 .bp_logo {
-	width: 280px;
-	height: 266px;
-	background: url('../images/backboneboilerplate_logo.png');
+  width: 280px;
+  height: 266px;
+  background: url('../images/backboneboilerplate_logo.png');
 }
 
 #springydemo {

--- a/index.html
+++ b/index.html
@@ -4,15 +4,15 @@
 <!--[if IE 8]>    <html class="no-js ie8 oldie" lang="en"> <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" xml:lang="en" lang="en"> <!--<![endif]-->
 <head>
-	<meta charset="utf-8" />
-	<meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
+  <meta charset="utf-8" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
 
-	<title>Backbone Boilerplate</title>
-	<meta name="viewport" content="width=device-width,initial-scale=1" />
-	<meta name="description" content="Backboneboilerplate.com is a community driven effort to help developers learn and rapidly deploy single page web applications" />
-	<link rel="stylesheet" href="css/styles.css" />
+  <title>Backbone Boilerplate</title>
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <meta name="description" content="Backboneboilerplate.com is a community driven effort to help developers learn and rapidly deploy single page web applications" />
+  <link rel="stylesheet" href="css/styles.css" />
 
-	<script data-main="js/main" src="js/libs/require/require.js"></script>
+  <script data-main="js/main" src="js/libs/require/require.js"></script>
 </head>
 <body>
   <!-- Initially populated by templates/layout.html -->
@@ -25,4 +25,4 @@
   <script>try{ clicky.init(66544553); }catch(e){}</script>
   
 </body>
-</html> 
+</html>

--- a/js/events.js
+++ b/js/events.js
@@ -3,6 +3,6 @@ define([
   'underscore',
   'backbone'
 ], function($, _, Backbone){
-	var vent = _.extend({}, Backbone.Events);
-	return vent;
+  var vent = _.extend({}, Backbone.Events);
+  return vent;
 });

--- a/js/router.js
+++ b/js/router.js
@@ -3,55 +3,55 @@ define([
   'jquery',
   'underscore',
   'backbone',
-	'vm'
+  'vm'
 ], function ($, _, Backbone, Vm) {
   var AppRouter = Backbone.Router.extend({
     routes: {
       // Pages
-      '/modules': 'modules',	
+      '/modules': 'modules',
       '/optimize': 'optimize',
       '/backbone/:section': 'backbone',
       '/backbone': 'backbone',
       '/manager': 'manager',
-    
+      
       // Default - catch all
       '*actions': 'defaultAction'
     }
   });
 
   var initialize = function(options){
-		var appView = options.appView;
+    var appView = options.appView;
     var router = new AppRouter(options);
-		router.on('route:optimize', function () {
-			require(['views/optimize/page'], function (OptimizePage) {
-				var optimizePage = Vm.create(appView, 'OptimizePage', OptimizePage);
-				optimizePage.render();
-			});
-		});
-		router.on('route:defaultAction', function (actions) {
-			require(['views/dashboard/page'], function (DashboardPage) {
+    router.on('route:optimize', function () {
+      require(['views/optimize/page'], function (OptimizePage) {
+        var optimizePage = Vm.create(appView, 'OptimizePage', OptimizePage);
+        optimizePage.render();
+      });
+    });
+    router.on('route:defaultAction', function (actions) {
+      require(['views/dashboard/page'], function (DashboardPage) {
         var dashboardPage = Vm.create(appView, 'DashboardPage', DashboardPage);
         dashboardPage.render();
       });
-		});
-		router.on('route:modules', function () {
-	   require(['views/modules/page'], function (ModulePage) {
+    });
+    router.on('route:modules', function () {
+     require(['views/modules/page'], function (ModulePage) {
         var modulePage = Vm.create(appView, 'ModulesPage', ModulePage);
         modulePage.render();
-      });	  	
-		});
-		router.on('route:backbone', function (section) {
+      });
+    });
+    router.on('route:backbone', function (section) {
       require(['views/backbone/page'], function (BackbonePage) {
         var backbonePage = Vm.create(appView, 'BackbonePage', BackbonePage, {section: section});
         backbonePage.render();
       });
-		});
-		router.on('route:manager', function () {
-			require(['views/manager/page'], function (ManagerPage) {
-				var managerPage = Vm.create(appView, 'ManagerPage', ManagerPage);
-				managerPage.render();
-			});
-		});
+    });
+    router.on('route:manager', function () {
+      require(['views/manager/page'], function (ManagerPage) {
+        var managerPage = Vm.create(appView, 'ManagerPage', ManagerPage);
+        managerPage.render();
+      });
+    });
     Backbone.history.start();
   };
   return {

--- a/js/views/app.js
+++ b/js/views/app.js
@@ -3,36 +3,36 @@ define([
   'underscore',
   'backbone',
   'vm',
-	'events',
-  'text!templates/layout.html' 
+  'events',
+  'text!templates/layout.html'
 ], function($, _, Backbone, Vm, Events, layoutTemplate){
   var AppView = Backbone.View.extend({
     el: '.container',
     initialize: function () {
-		
-      var NestedView2 = Backbone.View.extend({})
+    
+      var NestedView2 = Backbone.View.extend({});
       var NestedView1 = Backbone.View.extend({
-        initialize: function () { 
+        initialize: function () {
           var nestedView2 = Vm.create(this, 'Nested View 2', NestedView2);
-				}
-      })
+        }
+      });
       var nestedView1 = Vm.create(this, 'Nested View 1', NestedView1);
 
     },
     render: function () {
-			var that = this;
+      var that = this;
       $(this.el).html(layoutTemplate);
       require(['views/header/menu'], function (HeaderMenuView) {
         var headerMenuView = Vm.create(that, 'HeaderMenuView', HeaderMenuView);
         headerMenuView.render();
       });
-			require(['views/footer/footer'], function (FooterView) {
-				// Pass the appView down into the footer so we can render the visualisation
+      require(['views/footer/footer'], function (FooterView) {
+        // Pass the appView down into the footer so we can render the visualisation
         var footerView = Vm.create(that, 'FooterView', FooterView, {appView: that});
         footerView.render();
       });
-	  
-		} 
-	});
+    
+    }
+  });
   return AppView;
 });

--- a/js/views/backbone/page.js
+++ b/js/views/backbone/page.js
@@ -2,7 +2,7 @@ define([
   'jquery',
   'underscore',
   'backbone',
-	'vm',
+  'vm',
   'text!templates/backbone/page.html',
   'views/backbone/sidemenu',
   'views/backbone/section'

--- a/js/views/backbone/section.js
+++ b/js/views/backbone/section.js
@@ -2,7 +2,7 @@ define([
   'jquery',
   'underscore',
   'backbone',
-	'vm'
+  'vm'
 ], function($, _, Backbone, Vm){
   var BackbonePage = Backbone.View.extend({
     el: '.content',

--- a/js/views/dashboard/page.js
+++ b/js/views/dashboard/page.js
@@ -7,7 +7,7 @@ define([
   var DashboardPage = Backbone.View.extend({
     el: '.page',
     render: function () {
-		
+
       $(this.el).html(dashboardPageTemplate);
     }
   });

--- a/js/views/footer/footer.js
+++ b/js/views/footer/footer.js
@@ -2,9 +2,9 @@ define([
   'jquery',
   'underscore',
   'backbone',
-	'events',
+  'events',
   'text!templates/footer/footer.html',
-	'libs/springy/springyui'
+  'libs/springy/springyui'
 ], function($, _, Backbone, Events, footerTemplate, Springy){
   var FooterView = Backbone.View.extend({
     el: '.footer',
@@ -13,37 +13,37 @@ define([
     },
     render: function () {
       $(this.el).html(footerTemplate);
-			this.renderSpringy();
-			Events.on('viewCreated', this.renderSpringy, this);
+      this.renderSpringy();
+      Events.on('viewCreated', this.renderSpringy, this);
     },
-		renderSpringy: function () {
-			var that = this;
-			var graph = new Springy();
-			var generateGraph = function (context, parentName, first) {
-				if(typeof first === 'undefined'){
-					var first = graph.newNode({label: parentName});
-				}
-				_.each(context.children, function(view, viewname) {
-					var second = graph.newNode({label: viewname + ' (' + view.cid + ')'});
-					graph.newEdge(first, second, {color: '#000'});
-					generateGraph(view, viewname, second);
-				});
-				return;
-			}
-			
-			generateGraph(this.options.appView, 'AppView');
-			
-			$('#springydemo').remove();
-			$('.springy-container').html('<canvas id="springydemo" width="960px" height="820"></canvas">');
-		  var springy = $('#springydemo');
-			springy.springy({
-				graph: graph
-			});
-		},
-		clean: function () {
-			Events.off('viewCreated', this.renderSpringy);
-		}
-  })
+    renderSpringy: function () {
+      var that = this;
+      var graph = new Springy();
+      var generateGraph = function (context, parentName, first) {
+        if(typeof first === 'undefined'){
+          var first = graph.newNode({label: parentName});
+        }
+        _.each(context.children, function(view, viewname) {
+          var second = graph.newNode({label: viewname + ' (' + view.cid + ')'});
+          graph.newEdge(first, second, {color: '#000'});
+          generateGraph(view, viewname, second);
+        });
+        return;
+      };
+      
+      generateGraph(this.options.appView, 'AppView');
+      
+      $('#springydemo').remove();
+      $('.springy-container').html('<canvas id="springydemo" width="960px" height="820"></canvas">');
+      var springy = $('#springydemo');
+      springy.springy({
+        graph: graph
+      });
+    },
+    clean: function () {
+      Events.off('viewCreated', this.renderSpringy);
+    }
+  });
 
   return FooterView;
 });

--- a/js/views/header/menu.js
+++ b/js/views/header/menu.js
@@ -2,7 +2,7 @@ define([
   'jquery',
   'underscore',
   'backbone',
-  'text!templates/header/menu.html' 
+  'text!templates/header/menu.html'
 ], function($, _, Backbone, headerMenuTemplate){
   var HeaderMenuView = Backbone.View.extend({
     el: '.main-menu-container',

--- a/js/views/manager/page.js
+++ b/js/views/manager/page.js
@@ -2,7 +2,7 @@ define([
   'jquery',
   'underscore',
   'backbone',
-	'vm',
+  'vm',
   'text!templates/manager/page.html'
 ], function($, _, Backbone, Vm, managerPageTemplate){
   var ManagerPage = Backbone.View.extend({
@@ -10,16 +10,16 @@ define([
     render: function () {
       this.$el.html(managerPageTemplate);
     },
-		events: {
-		  'click .add-view': 'addView'
-		},
-		counter: 1,
-		addView: function () {
-			var RandomView = Backbone.View.extend({})
-			var randomView = Vm.create(this, 'RandomView ' + this.counter, RandomView);
-			this.counter++;
-			return false;
-		}
+    events: {
+      'click .add-view': 'addView'
+    },
+    counter: 1,
+    addView: function () {
+      var RandomView = Backbone.View.extend({});
+      var randomView = Vm.create(this, 'RandomView ' + this.counter, RandomView);
+      this.counter++;
+      return false;
+    }
   });
   return ManagerPage;
 });

--- a/js/vm.js
+++ b/js/vm.js
@@ -5,29 +5,29 @@ define([
   'backbone',
   'events'
 ], function($, _, Backbone, Events){
-	var views = {};
-	var create = function (context, name, View, options) {
-		// View clean up isn't actually implemented yet but will simply call .clean, .remove and .unbind
-		if(typeof views[name] !== 'undefined') {
-			views[name].undelegateEvents();
-			if(typeof views[name].clean === 'function') {
-				views[name].clean();
-			}
-		}
-		var view = new View(options);
-		views[name] = view;
-		if(typeof context.children === 'undefined'){
-		  context.children = {};
-		  context.children[name] = view;
-		} else {
-		  context.children[name] = view;
-		}
-		Events.trigger('viewCreated');
-		return view;
-	}
-	
-	
+  var views = {};
+  var create = function (context, name, View, options) {
+    // View clean up isn't actually implemented yet but will simply call .clean, .remove and .unbind
+    if(typeof views[name] !== 'undefined') {
+      views[name].undelegateEvents();
+      if(typeof views[name].clean === 'function') {
+        views[name].clean();
+      }
+    }
+    var view = new View(options);
+    views[name] = view;
+    if(typeof context.children === 'undefined'){
+      context.children = {};
+      context.children[name] = view;
+    } else {
+      context.children[name] = view;
+    }
+    Events.trigger('viewCreated');
+    return view;
+  };
+  
+  
   return {
-  	create: create
+    create: create
   };
 });

--- a/templates/dashboard/page.html
+++ b/templates/dashboard/page.html
@@ -1,23 +1,23 @@
 
-	<h3>Introduction</h3>
-	<p>This is a self-documenting example app useful for quick developer and/or learning backbone.js.</p>
-	<p>There are many boiler plates for Backbone.js boilerplates popping up over the place with different philosophies. 
-	This solution aims to be absolutely light-weight and robust keeping the following points in mind;</p>
-	<ul>
-	  <li>Stand on the shoulders of giants (Backbone.js, Underscore.js, Require.js, Html5Boilerplate) </li>
-	  <li>Perpetuate great and efficient practices for single page applications</li>
-	  <li>Optimized deployment consisting of one js file, one image sprite and one css file (with exceptions)</li>
-	  <li>One command optimization</li>
-	  <li>No enforced pre-compilation creating a low entry barrier to starting</li>
-	  <li>Modular environment (reusable, isolated testing)</li>
-	  <li>Speed!</li>
-	</ul>
-	<p>The project aims at being a modular backbone environment with as little authority on development as possible such that developers can innovate and contribute in an attempt to mimic the success of backbone.js ambiguous nature.</p>
+  <h3>Introduction</h3>
+  <p>This is a self-documenting example app useful for quick developer and/or learning backbone.js.</p>
+  <p>There are many boiler plates for Backbone.js boilerplates popping up over the place with different philosophies. 
+  This solution aims to be absolutely light-weight and robust keeping the following points in mind;</p>
+  <ul>
+    <li>Stand on the shoulders of giants (Backbone.js, Underscore.js, Require.js, Html5Boilerplate) </li>
+    <li>Perpetuate great and efficient practices for single page applications</li>
+    <li>Optimized deployment consisting of one js file, one image sprite and one css file (with exceptions)</li>
+    <li>One command optimization</li>
+    <li>No enforced pre-compilation creating a low entry barrier to starting</li>
+    <li>Modular environment (reusable, isolated testing)</li>
+    <li>Speed!</li>
+  </ul>
+  <p>The project aims at being a modular backbone environment with as little authority on development as possible such that developers can innovate and contribute in an attempt to mimic the success of backbone.js ambiguous nature.</p>
 
-	<h3>Getting started</h3>
-	<p>Simply clone the repo and serve the files on a http server (nginx, apache)</p>
-	<code>git clone https://github.com/thomasdavis/backboneboilerplate.git</code>
-	<p>Alternatively run</p>
+  <h3>Getting started</h3>
+  <p>Simply clone the repo and serve the files on a http server (nginx, apache)</p>
+  <code>git clone https://github.com/thomasdavis/backboneboilerplate.git</code>
+  <p>Alternatively run</p>
   <pre>node build/server</pre>
   <p>You may need to install Express</p>
   <pre>npm install express</pre>

--- a/templates/header/menu.html
+++ b/templates/header/menu.html
@@ -1,13 +1,13 @@
 <div class="divider"></div>
 <div class="main-menu">
-	<ul>
-		<li><a href="#/">Home</a></li>
-		<li><a href="#/modules">Modules</a></li>
-		<li><a href="#/optimize">Optimize</a></li>
-		<li><a href="#/backbone">Backbone</a></li>
-		<li><a href="#/manager">Views</a></li>
-		<li><a href="https://github.com/thomasdavis/backboneboilerplate/issues">Feedback</a></li>
-	</ul>
-	<div style="clear: both;"></div>
+  <ul>
+    <li><a href="#/">Home</a></li>
+    <li><a href="#/modules">Modules</a></li>
+    <li><a href="#/optimize">Optimize</a></li>
+    <li><a href="#/backbone">Backbone</a></li>
+    <li><a href="#/manager">Views</a></li>
+    <li><a href="https://github.com/thomasdavis/backboneboilerplate/issues">Feedback</a></li>
+  </ul>
+  <div style="clear: both;"></div>
 </div>
 <div class="divider"></div>

--- a/templates/manager/page.html
+++ b/templates/manager/page.html
@@ -2,12 +2,12 @@
 <em style="color: red">Incomplete</em>
 <p>This page talks about vm.js(View Manager) which is included in this boilerplate.   Vm.js helps control the life cycle of views and assist in areas such as;</p>
 <ul>
-	<li>Zombie Views</li>
-	<li>Duplicate Events</li>
-	<li>Organization of nested views</li>
+  <li>Zombie Views</li>
+  <li>Duplicate Events</li>
+  <li>Organization of nested views</li>
 </ul>
 
 <h3>Visualization</h3>
-<p>The View Manager can also be used for producing cool charts such as in the proof of concept in footer of the page.  
+<p>The View Manager can also be used for producing cool charts such as in the proof of concept in footer of the page. 
  I'd love to plot the Event bus on top of this graph in the future to see how your applications events are tied up</p>
 <p>Test: <a href="#" class="add-view">Add View</a></p>

--- a/templates/modules/page.html
+++ b/templates/modules/page.html
@@ -1,4 +1,4 @@
-<h3>'Modular' enviroment</h3>  
+<h3>'Modular' enviroment</h3>
 <p>
 Javascript currently lacks a native way to organized your code into modules unlike other languages.
 This has lead to developers writing spaghetti code or using global variable namespaces which both end


### PR DESCRIPTION
1) except in output and libraries, change tab to two-space convention already established by project
2) Remove trailing spaces (unless prepared at indent for new insertion)
3) Add a couple missing semicolons as per project's established convention

(Whitespace esp. was making difficult to read on Github; editors (like Notepad++) can be configured to convert tabs to 2 spaces)
