### PR TITLE
Layout top-margin fix

### DIFF
--- a/css/theme.css
+++ b/css/theme.css
@@ -166,6 +166,7 @@ Boilerplate Stamp!
 
 .container {
   margin-bottom: 150px;
+  margin-top: 4em;
 }
 
 code, pre {


### PR DESCRIPTION
First header was being cut off on all pages because the .container div was missing a margin-top. Fixed with margin-top: 4em.
