### PR TITLE
Fixed menu highlighting

### DIFF
--- a/js/views/header/menu.js
+++ b/js/views/header/menu.js
@@ -10,14 +10,14 @@ define([
     },
     render: function () {
       $(this.el).html(headerMenuTemplate);
-      $('a[href="' + window.location.hash + '"]').addClass('active');
+      $('a[href="' + window.location.hash + '"]').parent().addClass('active');
     },
     events: {
       'click a': 'highlightMenuItem'
     },
     highlightMenuItem: function (ev) {
       $('.active').removeClass('active');
-      $(ev.currentTarget).addClass('active');
+      $(ev.currentTarget).parent().addClass('active');
     }
   })
 

--- a/templates/header/menu.html
+++ b/templates/header/menu.html
@@ -11,7 +11,7 @@
           <a class="brand" href="#">Backbone Boilerplate</a>
           <div class="nav-collapse collapse">
             <ul class="nav">
-              <li class="active"><a href="#/">Home</a></li>
+              <li><a href="#/">Home</a></li>
               <li><a href="#/modules">Modules</a></li>
               <li><a href="#/optimize">Optimize</a></li>
               <li><a href="#/manager">Views</a></li>


### PR DESCRIPTION
The items in menu bar highlight properly.
However when browser back/forward buttons are pressed, the corresponding menu items do not highlight.
This can be addressed by updating to Backbone 1.0 and listening to Backbone.history from the view for any hash changes in url rather than listening to a click event.
Refer http://stackoverflow.com/questions/15109302/two-ways-route-functionality for details. 
